### PR TITLE
UPDATE: SDK compatibility to PredictionIO Server v0.9.4

### DIFF
--- a/Sensible.PredictionIO.NET/Clients/EngineClient.cs
+++ b/Sensible.PredictionIO.NET/Clients/EngineClient.cs
@@ -13,8 +13,8 @@ namespace Sensible.PredictionIO.NET.Clients
     public class EngineClient : BaseClient
     {
 
-        public EngineClient(string apiUrl)
-            : base(apiUrl)
+        public EngineClient(string apiUrl, string accessKey)
+            : base(apiUrl, accessKey)
         {
         }
 

--- a/Sensible.PredictionIO.NET/Clients/EventClient.cs
+++ b/Sensible.PredictionIO.NET/Clients/EventClient.cs
@@ -13,8 +13,8 @@ namespace Sensible.PredictionIO.NET.Clients
     {
         public int AppId { get; private set; }
 
-        public EventClient(string eventUrl, int appId)
-            : base(eventUrl)
+        public EventClient(string eventUrl, int appId, string accessKey)
+            : base(eventUrl, accessKey)
         {
             ApiUrl = eventUrl;
             AppId = appId;
@@ -52,7 +52,7 @@ namespace Sensible.PredictionIO.NET.Clients
         {
             var request = new Event(AppId, Constants.SetEvent, userId, Constants.User, null, null, properties);
             var body = request.ToString(Formatting.None);
-            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body);
+            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body).ConfigureAwait(false);
             return response[Constants.EventId].Value<string>();
         }
 
@@ -64,7 +64,7 @@ namespace Sensible.PredictionIO.NET.Clients
             }
             var request = new Event(AppId, Constants.UnsetEvent, userId, Constants.User, null, null, properties);
             var body = request.ToString(Formatting.None);
-            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body);
+            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body).ConfigureAwait(false);
             return response[Constants.EventId].Value<string>();
         }
 
@@ -126,7 +126,7 @@ namespace Sensible.PredictionIO.NET.Clients
             }
             var request = new Event(AppId, Constants.SetEvent, itemId, Constants.Item, null, null, properties);
             var body = request.ToString(Formatting.None);
-            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body);
+            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body).ConfigureAwait(false);
             return response[Constants.EventId].Value<string>();
         }
 
@@ -138,7 +138,7 @@ namespace Sensible.PredictionIO.NET.Clients
             }
             var request = new Event(AppId, Constants.UnsetEvent, itemId, Constants.Item, null, null, properties);
             var body = request.ToString(Formatting.None);
-            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body);
+            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body).ConfigureAwait(false);
             return response[Constants.EventId].Value<string>();
         }
 
@@ -164,7 +164,7 @@ namespace Sensible.PredictionIO.NET.Clients
             }
             var request = new Event(AppId, action, userId, Constants.User, itemId, Constants.Item, properties);
             var body = request.ToString(Formatting.None);
-            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body);
+            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body).ConfigureAwait(false);
             return response[Constants.EventId].Value<string>();
         }
 
@@ -175,7 +175,7 @@ namespace Sensible.PredictionIO.NET.Clients
 
         public async Task<string> RateItemAsync(string userId, string itemId, int rating)
         {
-            return await SetActionItemAsync(userId, itemId, Constants.Actions.Rate, rating);
+            return await SetActionItemAsync(userId, itemId, Constants.Actions.Rate, rating).ConfigureAwait(false);
         }
 
         public string DeleteItem(string itemId)
@@ -190,7 +190,7 @@ namespace Sensible.PredictionIO.NET.Clients
         {
             var request = new Event(AppId, Constants.DeleteEvent, itemId, Constants.Item, null, null, null);
             var body = request.ToString(Formatting.None);
-            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body);
+            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body).ConfigureAwait(false);
             return response[Constants.EventId].Value<string>();
         }
         
@@ -206,7 +206,7 @@ namespace Sensible.PredictionIO.NET.Clients
         {
             var request = new Event(AppId, Constants.DeleteEvent, userId, Constants.User, null, null, null);
             var body = request.ToString(Formatting.None);
-            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body);
+            var response = await ExecuteAsync(Constants.EventsResource, Method.POST, body).ConfigureAwait(false);
             return response[Constants.EventId].Value<string>();
         }
     }

--- a/Sensible.PredictionIO.NET/Constants.cs
+++ b/Sensible.PredictionIO.NET/Constants.cs
@@ -8,6 +8,7 @@ namespace Sensible.PredictionIO.NET
 {
     public class Constants
     {
+        public const int ClientTimeoutMS = 5000;
         public const string RootResource = "/";
         public const string EventsResource = "/events.json";
         public const string EngineResource = "/queries.json";
@@ -19,10 +20,10 @@ namespace Sensible.PredictionIO.NET
         public const string SetEvent = "$set";
         public const string UnsetEvent = "$unset";
         public const string DeleteEvent = "$delete";
-        public const string Item = "pio_item";
-        public const string User = "pio_user";
-        public const string ItemTypes = "pio_itypes";
-        public const string Rating = "pio_rating";
+        public const string Item = "item";
+        public const string User = "user";
+        public const string ItemTypes = "itypes";
+        public const string Rating = "rating";
         public const string UserId = "uid";
         public const string ItemIds = "iids";
         public const string Items = "items";
@@ -33,6 +34,7 @@ namespace Sensible.PredictionIO.NET
         public const string EventTime = "eventTime";
         public const string Alive = "alive";
         public const string AppId = "appId";
+        public const string AccessKey = "accessKey";
         public const string Event = "event";
         public const string ApplicationJsonContentType = "application/json";
 

--- a/Sensible.PredictionIO.NET/Sensible.PredictionIO.NET.csproj
+++ b/Sensible.PredictionIO.NET/Sensible.PredictionIO.NET.csproj
@@ -30,20 +30,33 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="RestSharp">
-      <HintPath>packages\RestSharp.104.5.0\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <Reference Include="System.Data">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml">
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Clients\BaseClient.cs" />

--- a/Sensible.PredictionIO.NET/packages.config
+++ b/Sensible.PredictionIO.NET/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
-  <package id="RestSharp" version="104.5.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
1. Use new App AccessKey Auth
2. Avoid context storage for await
3. Correct Headers for Content-Type
4. Remove incompatible keys consts
5. Update Newtonsoft to version 7.0.1 and ReshSharp to 105.2.3
